### PR TITLE
Add mutational spectrum as input for main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,25 +1,64 @@
+"""
+Decompose signatures using either:
+
+    1. MAF with annotated Ref_Tri column giving nucleotide context (made with make_trinuc_maf)
+    2. TSV mutational spectrum, i.e. base transition counts with column names in
+    same order as Stratton_signatures.txt. Rows start with sample names and each
+    value represents the number of times a certain base transition occurs in a
+    sample.
+"""
 import signature
 import sys
+import argparse
+from collections import OrderedDict
 
-if len(sys.argv) < 4:
-    print "Usage: python main.py [stratton signature path] [maf file path] [decomposed output file path]"
-    sys.exit(0)
 
-stratton_file = sys.argv[1]
-maf_file = sys.argv[2]
-out_file = sys.argv[3]
+def parse_mutational_spectum_tsv(mutational_spectrum_file):
+    """Return signature.make style mutational spectrum from tsv file. Assume
+    subsitution order is same as stratton_file."""
+    mut_spec = OrderedDict()
 
-print "Loading known signatures from %s"%stratton_file
-stratton = signature.load_stratton_signatures(stratton_file)
+    with open(mutational_spectrum_file) as msf:
+        for i, line in enumerate(msf):
+            # skip header
+            if i == 0:
+                continue
+            split_line = line.split()
+            # sample name first column, counts other columns
+            mut_spec[split_line[0]] = [int(v) for v in split_line[1:]]
 
-print "Making sample signatures from maf %s"%maf_file
-signatures = signature.make(maf_file, substitution_order=stratton['substitution_order'])
-if signatures == None:
-    print "Error during signature creation; quitting"
-    sys.exit(0)
+    return mut_spec
 
-print "Decomposing signatures and writing to %s"%out_file
-signature.decompose_to_file(signatures['signatures'], \
-                            stratton['signatures'], \
-                            stratton['names'], \
-                            out_file)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("stratton_file", type=str, help="Stratton Signatures file (included in repo)")
+    parser.add_argument("in_file", type=str, help="Either MAF file or "
+                        "mutational spectrum tsv (set --spectrum-tsv "
+                        "see --help)")
+    parser.add_argument("out_file", type=str, help="Output file")
+    parser.add_argument("--spectrum", action='store_true',
+                        default=False, help="input_file is "
+                        "mutational spectrum tsv instead of MAF")
+    args = parser.parse_args()
+
+    print "Loading known signatures from %s" % args.stratton_file
+    stratton = signature.load_stratton_signatures(args.stratton_file)
+
+    if args.spectrum:
+        signatures = {}
+        print "Parsing mutational spectrum tsv"
+        signatures['signatures'] = parse_mutational_spectum_tsv(args.in_file)
+    else:
+        print "Making sample signatures from maf %s" % args.in_file
+        signatures = signature.make(args.in_file, substitution_order=stratton['substitution_order'])
+
+        if signatures is None:
+            print "Error during signature creation; quitting"
+            sys.exit(0)
+
+    print "Decomposing signatures and writing to %s" % args.out_file
+    signature.decompose_to_file(signatures['signatures'],
+                                stratton['signatures'],
+                                stratton['names'],
+                                args.out_file)


### PR DESCRIPTION
Before main.py only accepted a maf annotated with a Ref_Tri column that shows
the trinucleotide context. This allows one to also use as input a tsv of the
base transition counts for each sample, a so called mutational spectrum.
Requirement for the input file is that the column order is the same as the
column transitions in the supplied Stratton_signatures.txt file and the first
column in each row should be the sample name. The values are the number of
times a base transition occurs.
